### PR TITLE
Change slack app to use a different template

### DIFF
--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -13,7 +13,7 @@
     {
 
         "Text": "Slack -> User Change Alerts",
-        "TemplateUrl": "https://raw.githubusercontent.com/anthonychu/slack-user-change-alerts/master/azuredeploy.json",
+        "TemplateUrl": "https://raw.githubusercontent.com/anthonychu/slack-user-change-alerts/master/azuredeploy.portal.json",
         "Repository": "https://github.com/anthonychu/slack-user-change-alerts/tree/master/src/SlackUserChangeAlerts.Function"
     }
 ]


### PR DESCRIPTION
- Uses the resource group location for all resources
- Links to original template which still allows location to be selected (for Deploy to Azure button)